### PR TITLE
ENH: Add `CTestConfig.cmake` file

### DIFF
--- a/CTestConfig.cmake
+++ b/CTestConfig.cmake
@@ -1,0 +1,7 @@
+set(CTEST_PROJECT_NAME "ITK")
+set(CTEST_NIGHTLY_START_TIME "1:00:00 UTC")
+
+set(CTEST_DROP_METHOD "http")
+set(CTEST_DROP_SITE "open.cdash.org")
+set(CTEST_DROP_LOCATION "/submit.php?project=Insight")
+set(CTEST_DROP_SITE_CDASH TRUE)


### PR DESCRIPTION
Add `CTestConfig.cmake` file to submit CI results to the `Insight` project
CDash dashboard.