### PR TITLE
STYLE: Prefer = default to explicitly trivial implementations

### DIFF
--- a/include/itkScancoImageIOFactory.h
+++ b/include/itkScancoImageIOFactory.h
@@ -58,7 +58,7 @@ public:
 
 protected:
   ScancoImageIOFactory();
-  ~ScancoImageIOFactory();
+  ~ScancoImageIOFactory() override = default;
 
 private:
   ITK_DISALLOW_COPY_AND_ASSIGN(ScancoImageIOFactory);

--- a/src/itkScancoImageIOFactory.cxx
+++ b/src/itkScancoImageIOFactory.cxx
@@ -30,9 +30,6 @@ ScancoImageIOFactory::ScancoImageIOFactory()
                           CreateObjectFunction< ScancoImageIO >::New() );
 }
 
-ScancoImageIOFactory::~ScancoImageIOFactory()
-{}
-
 const char *
 ScancoImageIOFactory::GetITKSourceVersion() const
 {


### PR DESCRIPTION
This check replaces default bodies of special member functions with
= default;. The explicitly defaulted function declarations enable more
opportunities in optimization, because the compiler might treat
explicitly defaulted functions as trivial.

Additionally, the C++11 use of = default more clearly expresses the
intent for the special member functions.