### PR TITLE
STYLE: Prefer constexpr for const numeric literals

### DIFF
--- a/test/itkScancoImageIOTest.cxx
+++ b/test/itkScancoImageIOTest.cxx
@@ -37,7 +37,7 @@ int itkScancoImageIOTest(int argc, char* argv[])
 
   // ATTENTION THIS IS THE PIXEL TYPE FOR
   // THE RESULTING IMAGE
-  const unsigned int Dimension = 3;
+  constexpr unsigned int Dimension = 3;
   typedef short                              PixelType;
   typedef itk::Image< PixelType, Dimension > ImageType;
 

--- a/test/itkScancoImageIOTest2.cxx
+++ b/test/itkScancoImageIOTest2.cxx
@@ -37,7 +37,7 @@ int itkScancoImageIOTest2(int argc, char* argv[])
 
   // ATTENTION THIS IS THE PIXEL TYPE FOR
   // THE RESULTING IMAGE
-  const unsigned int Dimension = 3;
+  constexpr unsigned int Dimension = 3;
   typedef short                              PixelType;
   typedef itk::Image< PixelType, Dimension > ImageType;
 


### PR DESCRIPTION
Use constexpr for constant numeric literals.