### PR TITLE
COMP: Move ITK_DISALLOW_COPY_AND_ASSIGN calls to public section

### DIFF
--- a/include/itkScancoImageIO.h
+++ b/include/itkScancoImageIO.h
@@ -69,6 +69,8 @@ namespace itk
 class IOScanco_EXPORT ScancoImageIO: public ImageIOBase
 {
 public:
+  ITK_DISALLOW_COPY_AND_ASSIGN(ScancoImageIO);
+
   /** Standard class typedefs. */
   typedef ScancoImageIO              Self;
   typedef ImageIOBase                Superclass;
@@ -215,7 +217,6 @@ protected:
   virtual void PrintSelf(std::ostream & os, Indent indent) const ITK_OVERRIDE;
 
 private:
-  ITK_DISALLOW_COPY_AND_ASSIGN(ScancoImageIO);
 
   /** Check the file header to see what type of file it is.
    *

--- a/include/itkScancoImageIOFactory.h
+++ b/include/itkScancoImageIOFactory.h
@@ -31,6 +31,8 @@ namespace itk
 class IOScanco_EXPORT ScancoImageIOFactory: public ObjectFactoryBase
 {
 public:
+  ITK_DISALLOW_COPY_AND_ASSIGN(ScancoImageIOFactory);
+
   /** Standard class typedefs. */
   typedef ScancoImageIOFactory       Self;
   typedef ObjectFactoryBase          Superclass;
@@ -59,9 +61,6 @@ public:
 protected:
   ScancoImageIOFactory();
   ~ScancoImageIOFactory();
-
-private:
-  ITK_DISALLOW_COPY_AND_ASSIGN(ScancoImageIOFactory);
 };
 } // end namespace itk
 


### PR DESCRIPTION
Move `ITK_DISALLOW_COPY_AND_ASSIGN` calls to public section following
the discussion in
https://discourse.itk.org/t/itk-disallow-copy-and-assign/648