### PR TITLE
STYLE: Prefer C++11 type alias over typedef

### DIFF
--- a/include/itkScancoImageIO.h
+++ b/include/itkScancoImageIO.h
@@ -70,10 +70,10 @@ class IOScanco_EXPORT ScancoImageIO: public ImageIOBase
 {
 public:
   /** Standard class typedefs. */
-  typedef ScancoImageIO              Self;
-  typedef ImageIOBase                Superclass;
-  typedef SmartPointer< Self >       Pointer;
-  typedef SmartPointer< const Self > ConstPointer;
+  using Self = ScancoImageIO;
+  using Superclass = ImageIOBase;
+  using Pointer = SmartPointer< Self >;
+  using ConstPointer = SmartPointer< const Self >;
 
   /** Method for creation through the object factory. */
   itkNewMacro(Self);

--- a/include/itkScancoImageIOFactory.h
+++ b/include/itkScancoImageIOFactory.h
@@ -32,10 +32,10 @@ class IOScanco_EXPORT ScancoImageIOFactory: public ObjectFactoryBase
 {
 public:
   /** Standard class typedefs. */
-  typedef ScancoImageIOFactory       Self;
-  typedef ObjectFactoryBase          Superclass;
-  typedef SmartPointer< Self >       Pointer;
-  typedef SmartPointer< const Self > ConstPointer;
+  using Self = ScancoImageIOFactory;
+  using Superclass = ObjectFactoryBase;
+  using Pointer = SmartPointer< Self >;
+  using ConstPointer = SmartPointer< const Self >;
 
   /** Class methods used to interface with the registered factories. */
   virtual const char * GetITKSourceVersion() const ITK_OVERRIDE;

--- a/test/itkScancoImageIOTest.cxx
+++ b/test/itkScancoImageIOTest.cxx
@@ -38,14 +38,14 @@ int itkScancoImageIOTest(int argc, char* argv[])
   // ATTENTION THIS IS THE PIXEL TYPE FOR
   // THE RESULTING IMAGE
   const unsigned int Dimension = 3;
-  typedef short                              PixelType;
-  typedef itk::Image< PixelType, Dimension > ImageType;
+  using PixelType = short;
+  using ImageType = itk::Image< PixelType, Dimension >;
 
-  typedef itk::ImageFileReader< ImageType > ReaderType;
+  using ReaderType = itk::ImageFileReader< ImageType >;
   ReaderType::Pointer reader = ReaderType::New();
 
   // force use of ScancoIO
-  typedef itk::ScancoImageIO IOType;
+  using IOType = itk::ScancoImageIO;
   IOType::Pointer scancoIO = IOType::New();
   reader->SetImageIO( scancoIO );
 
@@ -80,7 +80,7 @@ int itkScancoImageIOTest(int argc, char* argv[])
   std::cout << "region " << region;
 
   // Generate test image
-  typedef itk::ImageFileWriter< ImageType > WriterType;
+  using WriterType = itk::ImageFileWriter< ImageType >;
   WriterType::Pointer writer = WriterType::New();
   writer->SetInput( reader->GetOutput() );
   writer->SetFileName( outputFileName );

--- a/test/itkScancoImageIOTest2.cxx
+++ b/test/itkScancoImageIOTest2.cxx
@@ -38,14 +38,14 @@ int itkScancoImageIOTest2(int argc, char* argv[])
   // ATTENTION THIS IS THE PIXEL TYPE FOR
   // THE RESULTING IMAGE
   const unsigned int Dimension = 3;
-  typedef short                              PixelType;
-  typedef itk::Image< PixelType, Dimension > ImageType;
+  using PixelType = short;
+  using ImageType = itk::Image< PixelType, Dimension >;
 
-  typedef itk::ImageFileReader< ImageType > ReaderType;
+  using ReaderType = itk::ImageFileReader< ImageType >;
   ReaderType::Pointer reader = ReaderType::New();
 
   // force use of ScancoIO
-  typedef itk::ScancoImageIO IOType;
+  using IOType = itk::ScancoImageIO;
   IOType::Pointer scancoIO = IOType::New();
   reader->SetImageIO( scancoIO );
 
@@ -96,7 +96,7 @@ int itkScancoImageIOTest2(int argc, char* argv[])
   TEST_EXPECT_TRUE( itk::Math::FloatAlmostEqual( scancoIO->GetIntensity(), 0.177, 6, 1e-3 ) );
 
   // Generate test image
-  typedef itk::ImageFileWriter< ImageType > WriterType;
+  using WriterType = itk::ImageFileWriter< ImageType >;
   WriterType::Pointer writer = WriterType::New();
   if( argc > 3 )
     {


### PR DESCRIPTION
Prefer C++11 type alias over typedef for the reasons stated here:
http://review.source.kitware.com/#/c/23103/