### PR TITLE
ENH: Improve tests

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -5,7 +5,7 @@ set(IOScanco_LIBRARIES IOScanco)
 add_definitions(-D_CRT_SECURE_NO_WARNINGS)
 
 if(NOT ITK_SOURCE_DIR)
-  find_package(ITK 4.10 REQUIRED)
+  find_package(ITK 5.0 REQUIRED)
   list(APPEND CMAKE_MODULE_PATH ${ITK_CMAKE_DIR})
   include(ITKModuleExternal)
 else()

--- a/setup.py
+++ b/setup.py
@@ -13,7 +13,7 @@ except ImportError:
 
 setup(
     name='itk-ioscanco',
-    version='0.3.0',
+    version='0.4.0',
     author='Matt McCormick',
     author_email='matt.mccormick@kitware.com',
     packages=['itk'],
@@ -44,6 +44,6 @@ setup(
     keywords='ITK InsightToolkit',
     url=r'https://itk.org/',
     install_requires=[
-        r'itk>=5.0rc2'
+        r'itk>=5.0.1'
     ]
     )

--- a/test/azure-pipelines.yml
+++ b/test/azure-pipelines.yml
@@ -1,5 +1,5 @@
 variables:
-  ITKGitTag: v5.0rc02
+  ITKGitTag: v5.1b01
   CMakeBuildType: Release
 
 trigger:

--- a/test/itkScancoImageIOTest.cxx
+++ b/test/itkScancoImageIOTest.cxx
@@ -29,7 +29,10 @@ int itkScancoImageIOTest(int argc, char* argv[])
 {
   if( argc < 3 )
     {
-    std::cerr << "Usage: " << argv[0] << " Input Output \n";
+    std::cerr << "Missing parameters." << std::endl;
+    std::cerr << "Usage: " << std::endl;
+    std::cerr << itkNameOfTestExecutableMacro(argv)
+      << " Input Output" << std::endl;
     return EXIT_FAILURE;
     }
   const char * inputFileName = argv[1];
@@ -47,6 +50,10 @@ int itkScancoImageIOTest(int argc, char* argv[])
   // force use of ScancoIO
   using IOType = itk::ScancoImageIO;
   IOType::Pointer scancoIO = IOType::New();
+
+  ITK_EXERCISE_BASIC_OBJECT_METHODS( scancoIO, ScancoImageIO, ImageIOBase );
+
+
   reader->SetImageIO( scancoIO );
 
   // check usability of dimension (for coverage)
@@ -86,5 +93,7 @@ int itkScancoImageIOTest(int argc, char* argv[])
   writer->SetFileName( outputFileName );
   ITK_TRY_EXPECT_NO_EXCEPTION( writer->Update() );
 
+
+  std::cout << "Test finished" << std::endl;
   return EXIT_SUCCESS;
 }

--- a/test/itkScancoImageIOTest2.cxx
+++ b/test/itkScancoImageIOTest2.cxx
@@ -29,7 +29,10 @@ int itkScancoImageIOTest2(int argc, char* argv[])
 {
   if( argc < 3 )
     {
-    std::cerr << "Usage: " << argv[0] << " Input Output [ReUseIO]\n";
+    std::cerr << "Missing parameters." << std::endl;
+    std::cerr << "Usage: " << std::endl;
+    std::cerr << itkNameOfTestExecutableMacro(argv)
+      << " Input Output [ReUseIO]" << std::endl;
     return EXIT_FAILURE;
     }
   const std::string inputFileName = argv[1];
@@ -47,6 +50,10 @@ int itkScancoImageIOTest2(int argc, char* argv[])
   // force use of ScancoIO
   using IOType = itk::ScancoImageIO;
   IOType::Pointer scancoIO = IOType::New();
+
+  ITK_EXERCISE_BASIC_OBJECT_METHODS( scancoIO, ScancoImageIO, ImageIOBase );
+
+
   reader->SetImageIO( scancoIO );
 
   // read the file
@@ -111,5 +118,7 @@ int itkScancoImageIOTest2(int argc, char* argv[])
   writer->SetFileName( outputFileName );
   ITK_TRY_EXPECT_NO_EXCEPTION( writer->Update() );
 
+
+  std::cout << "Test finished" << std::endl;
   return EXIT_SUCCESS;
 }


### PR DESCRIPTION
Improve tests:
- Exercise basic object methods using the `EXERCISE_BASIC_OBJECT_METHODS`
  macro.
- Improve test argument checks: make the messages consistent according to
  the SW Guide and the `ITKModuleTemplaté` and use the
  `itkNameOfTestExecutableMacro` to prevent the test from crashing when
  `argv[0]` is null.
- Display the test end message in agreement with the SW Guide and the
  `ITKModuleTemplate`.