### PR TITLE
DOC: Improve `README` file

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -8,6 +8,26 @@ ITKIOScanco
 Overview
 --------
 
-An ITK module to read and write Scanco microCT .isq files.
+An `ITK <https://www.itk.org/>`_ module to read and write Scanco microCT .isq files.
 
 ITK is an open-source, cross-platform library that provides developers with an extensive suite of software tools for image analysis. Developed through extreme programming methodologies, ITK employs leading-edge algorithms for registering and segmenting multidimensional scientific images.
+
+
+Installation
+------------
+
+Python
+``````
+
+Binary `Python packages <https://pypi.python.org/pypi/itk-ioscanco>`_ are
+available for Linux, macOS, and Windows. They can be installed with::
+
+  python -m pip install --upgrade pip
+  python -m pip install itk-ioscanco
+
+
+License
+-------
+
+This software is distributed under the Apache 2.0 license. Please see the
+*LICENSE* file for details.

--- a/itk-module.cmake
+++ b/itk-module.cmake
@@ -1,7 +1,14 @@
-set(DOCUMENTATION "This module contains IO classes for reading and writing
-Scanco Medical microCT images. These images are usually saved as .isq or .aim
-files.")
+# the top-level README is used for describing this module, just
+# re-used it for documentation here
+get_filename_component(MY_CURRENT_DIR "${CMAKE_CURRENT_LIST_FILE}" PATH)
+file(READ "${MY_CURRENT_DIR}/README.rst" DOCUMENTATION)
 
+# itk_module() defines the module dependencies in IOScanco
+# The testing module in IOScanco depends on ITKTestKernel
+# By convention those modules outside of ITK are not prefixed with
+# ITK.
+
+# define the dependencies of the include module and the tests
 itk_module(IOScanco
   ENABLE_SHARED
   PRIVATE_DEPENDS


### PR DESCRIPTION
Improve `README` file:
- Add Python install instructions.
- Cross-reference the license.

Take advantage of the commit to re-use the `README.rst` file documentation
in the `itk-module.cmake` file.