### PR TITLE
STYLE: Rename ITK_DISALLOW_COPY_AND_ASSIGN to ITK_DISALLOW_COPY_A…

### DIFF
--- a/include/itkScancoImageIO.h
+++ b/include/itkScancoImageIO.h
@@ -69,7 +69,7 @@ namespace itk
 class IOScanco_EXPORT ScancoImageIO : public ImageIOBase
 {
 public:
-  ITK_DISALLOW_COPY_AND_ASSIGN(ScancoImageIO);
+  ITK_DISALLOW_COPY_AND_MOVE(ScancoImageIO);
 
   /** Standard class typedefs. */
   using Self = ScancoImageIO;

--- a/include/itkScancoImageIOFactory.h
+++ b/include/itkScancoImageIOFactory.h
@@ -31,7 +31,7 @@ namespace itk
 class IOScanco_EXPORT ScancoImageIOFactory : public ObjectFactoryBase
 {
 public:
-  ITK_DISALLOW_COPY_AND_ASSIGN(ScancoImageIOFactory);
+  ITK_DISALLOW_COPY_AND_MOVE(ScancoImageIOFactory);
 
   /** Standard class typedefs. */
   using Self = ScancoImageIOFactory;

--- a/src/itkScancoImageIO.cxx
+++ b/src/itkScancoImageIO.cxx
@@ -1338,7 +1338,7 @@ ScancoImageIO ::Write(const void * buffer)
 
   if (this->GetComponentType() != IOComponentEnum::SHORT)
   {
-    itkExceptionMacro("ScancoImageIO only supports writing short files.")
+    itkExceptionMacro("ScancoImageIO only supports writing short files.");
   }
 
   if (itk::ByteSwapper<short>::SystemIsBigEndian())


### PR DESCRIPTION
This PR fixes changes made in [#2053](https://github.com/InsightSoftwareConsortium/ITK/pull/2053/commits/4eac1a0cfb456fad1e3894173a41d7c7de49b08f). Essentially, `ITK_DISALLOW_COPY_AND_ASSIGN` has been changed to `ITK_DISALLOW_COPY_AND_MOVE` to more accurately convey the actions taking place. `ITK_DISALLOW_COPY_AND_ASSIGN` will **only** be used if `ITK_FUTURE_LEGACY_REMOVE=OFF`.

In addition a `;` was added to the end of some macros as this now required.

**NOTE:** These changes will cause the GitHub Actions to break, because they currently build `ITK v5.1.0`. The errors persist with `v5.1.1` as well (will update to newest version in separate PR). When tested locally against `master`, I get all tests to pass. The case is the same for the remaining 39 remote modules.