### PR TITLE
BUG: Fix itk package version specification

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -44,6 +44,6 @@ setup(
     keywords='ITK InsightToolkit',
     url=r'https://itk.org/',
     install_requires=[
-        r'itk>=v5.2rc01'
+        r'itk>=v5.2rc1'
     ]
     )


### PR DESCRIPTION
Python package versions do not include `0` in the `rc` version.