### PR TITLE
ENH: Initializing MuWater constant to the usual value

### DIFF
--- a/.github/workflows/build-test-package.yml
+++ b/.github/workflows/build-test-package.yml
@@ -13,17 +13,17 @@ jobs:
           - os: ubuntu-18.04
             c-compiler: "gcc"
             cxx-compiler: "g++"
-            itk-git-tag: "v5.2rc03"
+            itk-git-tag: "7548a390d71dc25b80e792703ee3cfea17853a99"
             cmake-build-type: "MinSizeRel"
           - os: windows-2019
             c-compiler: "cl.exe"
             cxx-compiler: "cl.exe"
-            itk-git-tag: "v5.2rc03"
+            itk-git-tag: "7548a390d71dc25b80e792703ee3cfea17853a99"
             cmake-build-type: "Release"
           - os: macos-10.15
             c-compiler: "clang"
             cxx-compiler: "clang++"
-            itk-git-tag: "v5.2rc03"
+            itk-git-tag: "7548a390d71dc25b80e792703ee3cfea17853a99"
             cmake-build-type: "MinSizeRel"
 
     steps:

--- a/src/itkScancoImageIO.cxx
+++ b/src/itkScancoImageIO.cxx
@@ -292,7 +292,7 @@ ScancoImageIO::InitializeHeader()
   memset(this->m_CalibrationData, 0, 66);
   this->m_RescaleSlope = 1.0;
   this->m_RescaleIntercept = 0.0;
-  this->m_MuWater = 0;
+  this->m_MuWater = 0.70329999923706055;
 
   this->m_Compression = 0;
   this->m_HeaderInitialized = true;


### PR DESCRIPTION
This ensures proper conversion to Hounsfield units
even if extended header (which contains MuWater) is absent.