### PR TITLE
ENH: Apply rescaling to compressed images

### DIFF
--- a/src/itkScancoImageIO.cxx
+++ b/src/itkScancoImageIO.cxx
@@ -1115,7 +1115,7 @@ ScancoImageIO::Read(void * buffer)
   if (this->m_Compression == 0)
   {
     infile.read(reinterpret_cast<char *>(buffer), outSize);
-    return;
+    size = outSize;
   }
   else if (this->m_Compression == 0x00b1)
   {

--- a/src/itkScancoImageIO.cxx
+++ b/src/itkScancoImageIO.cxx
@@ -1115,52 +1115,6 @@ ScancoImageIO::Read(void * buffer)
   if (this->m_Compression == 0)
   {
     infile.read(reinterpret_cast<char *>(buffer), outSize);
-
-    // Convert the image to HU by default
-    // Only SHORT images have been tested
-    IOComponentEnum dataType = this->m_ComponentType;
-
-    // The size of the buffer will change depending on the data type
-    size_t bufferSize = outSize;
-
-    if (this->m_RescaleSlope != 1.0 || this->m_RescaleIntercept != 0.0)
-    {
-      switch (dataType)
-      {
-        case IOComponentEnum::CHAR:
-          RescaleToHU(reinterpret_cast<char *>(buffer), bufferSize, this->m_RescaleSlope, this->m_RescaleIntercept);
-          break;
-        case IOComponentEnum::UCHAR:
-          RescaleToHU(
-            reinterpret_cast<unsigned char *>(buffer), bufferSize, this->m_RescaleSlope, this->m_RescaleIntercept);
-          break;
-        case IOComponentEnum::SHORT:
-          bufferSize /= 2;
-          RescaleToHU(reinterpret_cast<short *>(buffer), bufferSize, this->m_RescaleSlope, this->m_RescaleIntercept);
-          break;
-        case IOComponentEnum::USHORT:
-          bufferSize /= 2;
-          RescaleToHU(
-            reinterpret_cast<unsigned short *>(buffer), bufferSize, this->m_RescaleSlope, this->m_RescaleIntercept);
-          break;
-        case IOComponentEnum::INT:
-          bufferSize /= 4;
-          RescaleToHU(reinterpret_cast<int *>(buffer), bufferSize, this->m_RescaleSlope, this->m_RescaleIntercept);
-          break;
-        case IOComponentEnum::UINT:
-          bufferSize /= 4;
-          RescaleToHU(
-            reinterpret_cast<unsigned int *>(buffer), bufferSize, this->m_RescaleSlope, this->m_RescaleIntercept);
-          break;
-        case IOComponentEnum::FLOAT:
-          bufferSize /= 4;
-          RescaleToHU(reinterpret_cast<float *>(buffer), bufferSize, this->m_RescaleSlope, this->m_RescaleIntercept);
-          break;
-        default:
-          itkExceptionMacro("Unrecognized data type in file: " << dataType);
-      }
-    }
-
     return;
   }
   else if (this->m_Compression == 0x00b1)
@@ -1292,6 +1246,51 @@ ScancoImageIO::Read(void * buffer)
   }
 
   delete[] input;
+
+  // Convert the image to HU.
+  // Only SHORT images have been tested
+  IOComponentEnum dataType = this->m_ComponentType;
+
+  // The size of the buffer will change depending on the data type
+  size_t bufferSize = outSize;
+
+  if (this->m_RescaleSlope != 1.0 || this->m_RescaleIntercept != 0.0)
+  {
+    switch (dataType)
+    {
+      case IOComponentEnum::CHAR:
+        RescaleToHU(reinterpret_cast<char *>(buffer), bufferSize, this->m_RescaleSlope, this->m_RescaleIntercept);
+        break;
+      case IOComponentEnum::UCHAR:
+        RescaleToHU(
+          reinterpret_cast<unsigned char *>(buffer), bufferSize, this->m_RescaleSlope, this->m_RescaleIntercept);
+        break;
+      case IOComponentEnum::SHORT:
+        bufferSize /= 2;
+        RescaleToHU(reinterpret_cast<short *>(buffer), bufferSize, this->m_RescaleSlope, this->m_RescaleIntercept);
+        break;
+      case IOComponentEnum::USHORT:
+        bufferSize /= 2;
+        RescaleToHU(
+          reinterpret_cast<unsigned short *>(buffer), bufferSize, this->m_RescaleSlope, this->m_RescaleIntercept);
+        break;
+      case IOComponentEnum::INT:
+        bufferSize /= 4;
+        RescaleToHU(reinterpret_cast<int *>(buffer), bufferSize, this->m_RescaleSlope, this->m_RescaleIntercept);
+        break;
+      case IOComponentEnum::UINT:
+        bufferSize /= 4;
+        RescaleToHU(
+          reinterpret_cast<unsigned int *>(buffer), bufferSize, this->m_RescaleSlope, this->m_RescaleIntercept);
+        break;
+      case IOComponentEnum::FLOAT:
+        bufferSize /= 4;
+        RescaleToHU(reinterpret_cast<float *>(buffer), bufferSize, this->m_RescaleSlope, this->m_RescaleIntercept);
+        break;
+      default:
+        itkExceptionMacro("Unrecognized data type in file: " << dataType);
+    }
+  }
 }
 
 


### PR DESCRIPTION
Scanco images can only be compressed if they are segmentation images,
however, they still need to be rescaled to HU as is done with grayscale.