### PR TITLE
COMP: Add missing module dependency on ITKIOImageBase

### DIFF
--- a/itk-module.cmake
+++ b/itk-module.cmake
@@ -10,7 +10,7 @@ file(READ "${MY_CURRENT_DIR}/README.rst" DOCUMENTATION)
 
 # define the dependencies of the include module and the tests
 itk_module(IOScanco
-  PRIVATE_DEPENDS
+  DEPENDS
     ITKIOImageBase
   TEST_DEPENDS
     ITKTestKernel


### PR DESCRIPTION
Fixing compile error which occurs during wrapping:

C:/Dev/ITK-vs22/Wrapping/castxml_inputs/itkScancoImageIO.cxx:1:10: fatal error: 'itkCommand.h' file not found