### PR TITLE
STYLE: Apply clang-format 19.1.7 to fix lint failure on main

### DIFF
--- a/include/itkScancoImageIO.h
+++ b/include/itkScancoImageIO.h
@@ -193,8 +193,7 @@ public:
   void
   SetRescaleUnits(const char * rescaleUnits)
   {
-    std::snprintf(
-      this->m_HeaderData.m_RescaleUnits, sizeof(this->m_HeaderData.m_RescaleUnits), "%s", rescaleUnits);
+    std::snprintf(this->m_HeaderData.m_RescaleUnits, sizeof(this->m_HeaderData.m_RescaleUnits), "%s", rescaleUnits);
     this->Modified();
   }
 
@@ -299,8 +298,7 @@ public:
   void
   SetCreationDate(const char * creationDate)
   {
-    std::snprintf(
-      this->m_HeaderData.m_CreationDate, sizeof(this->m_HeaderData.m_CreationDate), "%s", creationDate);
+    std::snprintf(this->m_HeaderData.m_CreationDate, sizeof(this->m_HeaderData.m_CreationDate), "%s", creationDate);
     this->Modified();
   }
 
@@ -312,10 +310,8 @@ public:
   void
   SetModificationDate(const char * modificationDate)
   {
-    std::snprintf(this->m_HeaderData.m_ModificationDate,
-                  sizeof(this->m_HeaderData.m_ModificationDate),
-                  "%s",
-                  modificationDate);
+    std::snprintf(
+      this->m_HeaderData.m_ModificationDate, sizeof(this->m_HeaderData.m_ModificationDate), "%s", modificationDate);
     this->Modified();
   }
 

--- a/src/itkISQHeaderIO.cxx
+++ b/src/itkISQHeaderIO.cxx
@@ -413,9 +413,8 @@ ISQHeaderIO::ReadExtendedHeader(const char * buffer, unsigned long length)
   if (calHeader && calHeaderSize >= 1024)
   {
     // Read Calibration data from header
-    StripString(this->m_HeaderData->m_CalibrationData,
-                calHeader->m_CalibrationData,
-                ScancoHeaderField::CalibrationDataDiskWidth);
+    StripString(
+      this->m_HeaderData->m_CalibrationData, calHeader->m_CalibrationData, ScancoHeaderField::CalibrationDataDiskWidth);
     // std::string calFile(h + 112, 256);
     // std::string s3(h + 376, 256);
     this->m_HeaderData->m_RescaleType = DecodeInt(calHeader->m_RescaleType);

--- a/src/itkScancoImageIO.cxx
+++ b/src/itkScancoImageIO.cxx
@@ -359,8 +359,7 @@ ScancoImageIO::SetHeaderFromMetaDataDictionary()
   }
   if (ExposeMetaData<std::string>(metaData, "PatientName", stringMeta))
   {
-    std::snprintf(
-      this->m_HeaderData.m_PatientName, sizeof(this->m_HeaderData.m_PatientName), "%s", stringMeta.c_str());
+    std::snprintf(this->m_HeaderData.m_PatientName, sizeof(this->m_HeaderData.m_PatientName), "%s", stringMeta.c_str());
   }
 
   ExposeMetaData<int>(metaData, "PatientIndex", this->m_HeaderData.m_PatientIndex);
@@ -373,10 +372,8 @@ ScancoImageIO::SetHeaderFromMetaDataDictionary()
   }
   if (ExposeMetaData<std::string>(metaData, "ModificationDate", stringMeta))
   {
-    std::snprintf(this->m_HeaderData.m_ModificationDate,
-                  sizeof(this->m_HeaderData.m_ModificationDate),
-                  "%s",
-                  stringMeta.c_str());
+    std::snprintf(
+      this->m_HeaderData.m_ModificationDate, sizeof(this->m_HeaderData.m_ModificationDate), "%s", stringMeta.c_str());
   }
 
   ExposeMetaData<double>(metaData, "SliceThickness", this->m_HeaderData.m_SliceThickness);


### PR DESCRIPTION
The clang-format CI lint job has been failing on `main` since #109 merged ([failing run](https://github.com/InsightSoftwareConsortium/ITKIOScanco/actions/runs/25185923269)). Re-running clang-format 19.1.7 (the version pinned by ITK upstream's `.pre-commit-config.yaml`) re-wraps three multi-arg `std::snprintf` / `StripString` call sites that drifted past the column limit.

<details>
<summary>Verification</summary>

- ITK upstream pin: `https://github.com/pre-commit/mirrors-clang-format` `rev: v19.1.7` (`upstream/main:.pre-commit-config.yaml`).
- IOScanco's `.clang-format` is byte-identical to ITK upstream/main — no style update needed.
- Ran `clang-format -i --style=file` (v19.1.7) over every `*.{c,cc,cxx,cpp,h,hxx,hpp}` in `include/`, `src/`, `test/` (15 files). Only 3 files changed; the remainder are already compliant.

</details>

<!--
provenance: claude-code session 2026-04-30
key_facts:
  - ci_failure_run: https://github.com/InsightSoftwareConsortium/ITKIOScanco/actions/runs/25185923269
  - clang_format_version: 19.1.7 (from ITK upstream/main .pre-commit-config.yaml)
  - dot_clang_format_state: identical to ITK upstream/main
related_files:
  - include/itkScancoImageIO.h
  - src/itkISQHeaderIO.cxx
  - src/itkScancoImageIO.cxx
post_merge_action: clang-format CI on main should go green on next push.
-->